### PR TITLE
Update deprecated math error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ configs
 logs
 pilots
 savegame
+*.dll
+gmon.out

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ endif
 # dynamic only libraries
 LIB+= `pkg-config --libs $(SDL_)`
 ifeq ($(MINGW),1)
+  CFLAGS += -DMINGW
   LIB += -L./mingw/bin
   LIB += -lglu32 -lopengl32
   LIB += -lsocket -lws2_32 -lwsock32 -lwinmm -lOpenAL32

--- a/main.c
+++ b/main.c
@@ -411,8 +411,8 @@ extern RENDEROBJECT RenderBufs[4];
 
 static bool AppInit( char * lpCmdLine )
 {
-#if defined(DEBUG_ON) && defined(_SVID_)
-	_LIB_VERSION = _SVID_; // enable matherr
+#ifdef DEBUG_ON
+	InitMathErrors();
 #endif
 
 	ZERO_STACK_MEM(render_info);
@@ -580,7 +580,6 @@ static bool RenderLoop()
 // The main routine
 //
 
-extern int DebugMathErrors( void );
 extern void network_cleanup( void );
 extern bool SeriousError;
 extern void CleanUpAndPostQuit(void);
@@ -639,6 +638,10 @@ int main( int argc, char* argv[] )
 		// command line asks us to sleep and free up sys resources a bit...
 		if ( cliSleep )
 			SDL_Delay( cliSleep );
+
+#if defined(DEBUG_ON) && defined(DEBUG_ALL_MATH_ERRORS)
+		DebugMathErrors();
+#endif
 	}
 
 	DebugPrintf("exit(0)\n");

--- a/main.h
+++ b/main.h
@@ -114,13 +114,7 @@ typedef struct
 // _strupr use strtoupper see util.h
 #endif
 
-#ifdef DEBUG_ON
-#ifndef _SVID_SOURCE
-#define _SVID_SOURCE
-#endif
-#include <errno.h>
-#include <math.h>
-#endif
+#include "math_error.h"
 
 // c99 boolean support
 #include <stdbool.h>

--- a/math_error.h
+++ b/math_error.h
@@ -1,0 +1,36 @@
+#ifndef MATH_ERROR
+#define MATH_ERROR
+#ifdef DEBUG_ON
+
+extern void InitMathErrors( void );
+extern int DebugMathErrors( void );
+
+// mingw still appears to support matherr so we'll leave it for now
+// not sure if msvc still does but it appears matherr is going away
+#if defined(WIN32) && !defined(MINGW)
+
+// note this is no longer really needed either
+// it was only here for matherr support and should be removed along with it
+// https://stackoverflow.com/questions/29201515/what-does-d-default-source-do
+// https://stackoverflow.com/questions/5582211/what-does-define-gnu-source-imply
+// https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
+#ifndef _SVID_SOURCE
+#define _SVID_SOURCE
+#endif
+
+#include <errno.h>
+#include <math.h>
+
+#else // NOT WIN32
+
+// https://man7.org/linux/man-pages/man3/matherr.3.html
+// https://man7.org/linux/man-pages/man7/math_error.7.html
+// https://man7.org/linux/man-pages/man3/fenv.3.html
+#include <math.h>
+#include <errno.h>
+#include <fenv.h>
+
+#endif
+
+#endif // DEBUG_ON
+#endif // MATH_ERROR


### PR DESCRIPTION
The old SVID (SysV) matherr() is being deprecated as of glibc 2.27.
- https://man7.org/linux/man-pages/man3/matherr.3.html

Updating non-win32 targets (except for MINGW) to use the new approach.
- https://man7.org/linux/man-pages/man7/math_error.7.html

For now leaving the old code as-is in case it's still required under
msvc.
 