### PR TITLE
fix: linker error when compiling headless

### DIFF
--- a/render_disabled.c
+++ b/render_disabled.c
@@ -173,6 +173,8 @@ float render_lighting_env_water_green = 0.0f;
 float render_lighting_env_water_blue  = 0.0f;
 int render_lighting_env_whiteout = 0;
 
+bool bSquareOnly = true;
+
 const char * render_error_description( int e ) { return NULL; }
 
 #endif // RENDER_DISABLED


### PR DESCRIPTION
bool bSquareOnly is used in mload.c, but not
declared when compiling with RENDER_DISABLED=1